### PR TITLE
fix(ci): downgrade ruby to 3.3 for chirpy 7.5 compatibility

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 4.0.2
+          ruby-version: 3.3
           bundler-cache: true
 
       - name: Build site

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ plans/
 # Misc
 _sass/vendors
 assets/js/dist
+
+# AI
+.claude/


### PR DESCRIPTION
## Summary
- Downgrade Ruby from 4.x to 3.3 in CI — `jekyll-theme-chirpy >= 7.1` requires `~> 3.1` (3.x only)
- Add `.claude/` to `.gitignore`

## Test plan
- [ ] Verify GitHub Actions build passes with Ruby 3.3
- [ ] Verify site deploys correctly to GitHub Pages